### PR TITLE
Fix link for heroicons site

### DIFF
--- a/lib/heroicons.ex
+++ b/lib/heroicons.ex
@@ -1,6 +1,6 @@
 defmodule Heroicons do
   @moduledoc """
-  Provides precompiled icon compiles from [heroicons.com v2.0.13](heroicons.com).
+  Provides precompiled icon compiles from [heroicons.com v2.0.13](https://heroicons.com).
 
   Heroicons are designed by [Steve Schoger](https://twitter.com/steveschoger)
 


### PR DESCRIPTION
Hi, I noticed that clicking on the heroicons.com link from https://hexdocs.pm/heroicons/Heroicons.html was linking correctly.