### PR TITLE
fix broken link in docs

### DIFF
--- a/assets/heroicons.exs
+++ b/assets/heroicons.exs
@@ -1,6 +1,6 @@
 defmodule Heroicons do
   @moduledoc """
-  Provides precompiled icon compiles from [heroicons.com v<%= @vsn %>](heroicons.com).
+  Provides precompiled icon compiles from [heroicons.com v<%= @vsn %>](https://heroicons.com).
 
   Heroicons are designed by [Steve Schoger](https://twitter.com/steveschoger)
 

--- a/lib/heroicons.ex
+++ b/lib/heroicons.ex
@@ -1,6 +1,6 @@
 defmodule Heroicons do
   @moduledoc """
-  Provides precompiled icon compiles from [heroicons.com v2.1.5](heroicons.com).
+  Provides precompiled icon compiles from [heroicons.com v2.1.5](https://heroicons.com).
 
   Heroicons are designed by [Steve Schoger](https://twitter.com/steveschoger)
 


### PR DESCRIPTION
Prior to this commit, the documenation hosted at hexdocs.pm would render the wrong link for the heroicons website because the markup was lacking the protocol scheme, which would cause the link to be interpreted as a relative link to https://hexdocs.pm/heroicons/heroicons.com rather than one out to https://heroicons.com. This commit fixes both the generated `lib/heroicons.ex` and the source `assets/heroicons.exs`.